### PR TITLE
Fix duplicate assembly attributes

### DIFF
--- a/Core/VibeQuest.Core.csproj
+++ b/Core/VibeQuest.Core.csproj
@@ -3,5 +3,6 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 </Project>

--- a/Infrastructure/VibeQuest.Infrastructure.csproj
+++ b/Infrastructure/VibeQuest.Infrastructure.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />

--- a/Tests/VibeQuest.Tests.csproj
+++ b/Tests/VibeQuest.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/UI/VibeQuest.UI.csproj
+++ b/UI/VibeQuest.UI.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\VibeQuest.Core.csproj" />

--- a/VibeQuest.Tests/VibeQuest.Tests.csproj
+++ b/VibeQuest.Tests/VibeQuest.Tests.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>

--- a/VibeQuest.UI/VibeQuest.UI.csproj
+++ b/VibeQuest.UI/VibeQuest.UI.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
 </Project>

--- a/VibeQuestV2.Tests/VibeQuestV2.Tests.csproj
+++ b/VibeQuestV2.Tests/VibeQuestV2.Tests.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>

--- a/VibeQuestV2.csproj
+++ b/VibeQuestV2.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UserSecretsId>aspnet-VibeQuestV2-b5f463c8-6b06-4e65-90ff-93eac93c80da</UserSecretsId>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- disable automatically generated assembly metadata in all projects

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fc76104b48330b108944ecd210947